### PR TITLE
Add a basic routing tool rather than hard-coding URLs

### DIFF
--- a/_data/routes.yml
+++ b/_data/routes.yml
@@ -1,0 +1,5 @@
+home:        "/"
+guidelines:  "/guide/"
+repository:  "https://github.com/deliveroo/deliveroo.engineering"
+design_blog: "http://deliveroo.design/"
+food_blog:   "http://deliveroo.co.uk/blog"


### PR DESCRIPTION
See: https://www.sitepoint.com/hacking-routing-component-jekyll/

We’re writing templates in HTML/Liquid rather than Markdown, but it should still make it easier to keep routes up to date than manually typing them in places.