### PR TITLE
Add basic articles placeholder index

### DIFF
--- a/articles/index.html
+++ b/articles/index.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+<h2>Articles</h2>
+<ul>
+  {% for _page in site.posts %}
+    {% if _page.title %}
+      <li>
+        <a href="{{ site.baseurl }}{{ _page.url }}">{{ _page.title }}</a>
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>


### PR DESCRIPTION
This is a placeholder index page for the `/articles/` page.