### PR TITLE
Fix indentation preventing Rouge syntax highlighting

### DIFF
--- a/_guidelines/javascript.md
+++ b/_guidelines/javascript.md
@@ -22,480 +22,480 @@ Taken in part from the following sources:
 
 ## Destructuring
 
-  <a name="destructuring--object"></a>
-  - [Objects](#destructuring--object): Use object destructuring when accessing and using multiple properties of an object. jscs: [`requireObjectDestructuring`](http://jscs.info/rule/requireObjectDestructuring)
+<a name="destructuring--object"></a>
+- [Objects](#destructuring--object): Use object destructuring when accessing and using multiple properties of an object. jscs: [`requireObjectDestructuring`](http://jscs.info/rule/requireObjectDestructuring)
 
-    > Why? Destructuring saves you from creating temporary references for those properties.
+> Why? Destructuring saves you from creating temporary references for those properties.
 
-    ```javascript
-    // bad
-    function getFullName(user) {
-      const firstName = user.firstName;
-      const lastName = user.lastName;
+```javascript
+// bad
+function getFullName(user) {
+  const firstName = user.firstName;
+  const lastName = user.lastName;
 
-      return `${firstName} ${lastName}`;
-    }
+  return `${firstName} ${lastName}`;
+}
 
-    // good
-    function getFullName(user) {
-      const { firstName, lastName } = user;
-      return `${firstName} ${lastName}`;
-    }
+// good
+function getFullName(user) {
+  const { firstName, lastName } = user;
+  return `${firstName} ${lastName}`;
+}
 
-    // best
-    function getFullName({ firstName, lastName }) {
-      return `${firstName} ${lastName}`;
-    }
-    ```
+// best
+function getFullName({ firstName, lastName }) {
+  return `${firstName} ${lastName}`;
+}
+```
 
-  <a name="destructuring--array"></a><a name="5.2"></a>
-  - [Arrays](#destructuring--array): Use array destructuring. jscs: [`requireArrayDestructuring`](http://jscs.info/rule/requireArrayDestructuring)
+<a name="destructuring--array"></a><a name="5.2"></a>
+- [Arrays](#destructuring--array): Use array destructuring. jscs: [`requireArrayDestructuring`](http://jscs.info/rule/requireArrayDestructuring)
 
-    ```javascript
-    const arr = [1, 2, 3, 4];
+```javascript
+const arr = [1, 2, 3, 4];
 
-    // bad
-    const first = arr[0];
-    const second = arr[1];
+// bad
+const first = arr[0];
+const second = arr[1];
 
-    // good
-    const [first, second] = arr;
-    ```
+// good
+const [first, second] = arr;
+```
 
-  <a name="destructuring--object-over-array"></a><a name="5.3"></a>
-  - [Objects over arrays](#destructuring--object-over-array): Use object destructuring for multiple return values, not array destructuring. jscs: [`disallowArrayDestructuringReturn`](http://jscs.info/rule/disallowArrayDestructuringReturn)
+<a name="destructuring--object-over-array"></a><a name="5.3"></a>
+- [Objects over arrays](#destructuring--object-over-array): Use object destructuring for multiple return values, not array destructuring. jscs: [`disallowArrayDestructuringReturn`](http://jscs.info/rule/disallowArrayDestructuringReturn)
 
-    > Why? You can add new properties over time or change the order of things without breaking call sites.
+> Why? You can add new properties over time or change the order of things without breaking call sites.
 
-    ```javascript
-    // bad
-    function processInput(input) {
-      // then a miracle occurs
-      return [left, right, top, bottom];
-    }
+```javascript
+// bad
+function processInput(input) {
+  // then a miracle occurs
+  return [left, right, top, bottom];
+}
 
-    // the caller needs to think about the order of return data
-    const [left, __, top] = processInput(input);
+// the caller needs to think about the order of return data
+const [left, __, top] = processInput(input);
 
-    // good
-    function processInput(input) {
-      // then a miracle occurs
-      return { left, right, top, bottom };
-    }
+// good
+function processInput(input) {
+  // then a miracle occurs
+  return { left, right, top, bottom };
+}
 
-    // the caller selects only the data they need
-    const { left, top } = processInput(input);
-    ```
+// the caller selects only the data they need
+const { left, top } = processInput(input);
+```
 
 **[⬆ back to top](#table-of-contents)**
 
-  ## Types
+## Types
 
-  <a name="types--primitives"></a><a name="1.1"></a>
-  - [Primitives](#types--primitives): When you access a primitive type you work directly on its value.
+<a name="types--primitives"></a><a name="1.1"></a>
+- [Primitives](#types--primitives): When you access a primitive type you work directly on its value.
 
-  + `string`
-  + `number`
-  + `boolean`
-  + `null`
-  + `undefined`
++ `string`
++ `number`
++ `boolean`
++ `null`
++ `undefined`
 
-  ```javascript
-  const foo = 1;
-  let bar = foo;
+```javascript
+const foo = 1;
+let bar = foo;
 
-  bar = 9;
+bar = 9;
 
-  console.log(foo, bar); // => 1, 9
-  ```
+console.log(foo, bar); // => 1, 9
+```
 
-  <a name="types--complex"></a><a name="1.2"></a>
-  - [Complex](#types--complex): When you access a complex type you work on a reference to its value; changes to the value (as long as it's not overwritten with a new value) will mutate the pointer value.
+<a name="types--complex"></a><a name="1.2"></a>
+- [Complex](#types--complex): When you access a complex type you work on a reference to its value; changes to the value (as long as it's not overwritten with a new value) will mutate the pointer value.
 
-  + `object`
-  + `array`
-  + `function`
++ `object`
++ `array`
++ `function`
 
-  ```javascript
-  const foo = [1, 2];
-  const bar = foo;
+```javascript
+const foo = [1, 2];
+const bar = foo;
 
-  bar[0] = 9;
+bar[0] = 9;
 
-  console.log(foo[0], bar[0]); // => 9, 9
-  ```
+console.log(foo[0], bar[0]); // => 9, 9
+```
 
-  **[⬆ back to top](#table-of-contents)**
+**[⬆ back to top](#table-of-contents)**
 
 ## Commas
 
 <a name="commas--leading-trailing"></a>
-  - [Leading commas:](#commas--leading-trailing) **Nope.** eslint: [`comma-style`](http://eslint.org/docs/rules/comma-style.html) jscs: [`requireCommaBeforeLineBreak`](http://jscs.info/rule/requireCommaBeforeLineBreak)
+- [Leading commas:](#commas--leading-trailing) **Nope.** eslint: [`comma-style`](http://eslint.org/docs/rules/comma-style.html) jscs: [`requireCommaBeforeLineBreak`](http://jscs.info/rule/requireCommaBeforeLineBreak)
 
-    ```javascript
-    // bad
-    const story = [
-        once
-      , upon
-      , aTime
-    ];
+```javascript
+// bad
+const story = [
+    once
+  , upon
+  , aTime
+];
 
-    // good
-    const story = [
-      once,
-      upon,
-      aTime,
-    ];
+// good
+const story = [
+  once,
+  upon,
+  aTime,
+];
 
-    // bad
-    const hero = {
-        firstName: 'Ada'
-      , lastName: 'Lovelace'
-      , birthYear: 1815
-      , superPower: 'computers'
-    };
+// bad
+const hero = {
+    firstName: 'Ada'
+  , lastName: 'Lovelace'
+  , birthYear: 1815
+  , superPower: 'computers'
+};
 
-    // good
-    const hero = {
-      firstName: 'Ada',
-      lastName: 'Lovelace',
-      birthYear: 1815,
-      superPower: 'computers',
-    };
+// good
+const hero = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  birthYear: 1815,
+  superPower: 'computers',
+};
 
-    // etc
-    ```
+// etc
+```
 
-  <a name="commas--dangling"></a>
-  - [Additional trailing comma:](#commas--dangling) **Yup.** eslint: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html) jscs: [`requireTrailingComma`](http://jscs.info/rule/requireTrailingComma)
+<a name="commas--dangling"></a>
+- [Additional trailing comma:](#commas--dangling) **Yup.** eslint: [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle.html) jscs: [`requireTrailingComma`](http://jscs.info/rule/requireTrailingComma)
 
-    > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](https://satishchilukuri.com/blog/entry/ie-8-and-trailing-commas-in-javascript) in legacy browsers.
+> Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](https://satishchilukuri.com/blog/entry/ie-8-and-trailing-commas-in-javascript) in legacy browsers.
 
-    ```diff
-    // bad - git diff without trailing comma
-    const hero = {
-         firstName: 'Florence',
-    -    lastName: 'Nightingale'
-    +    lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'modern nursing']
-    };
+```diff
+// bad - git diff without trailing comma
+const hero = {
+     firstName: 'Florence',
+-    lastName: 'Nightingale'
++    lastName: 'Nightingale',
++    inventorOf: ['coxcomb chart', 'modern nursing']
+};
 
-    // good - git diff with trailing comma
-    const hero = {
-         firstName: 'Florence',
-         lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'modern nursing'],
-    };
-    ```
-    ```javascript
-    // bad
-    const hero = {
-      firstName: 'Dana',
-      lastName: 'Scully'
-    };
+// good - git diff with trailing comma
+const hero = {
+     firstName: 'Florence',
+     lastName: 'Nightingale',
++    inventorOf: ['coxcomb chart', 'modern nursing'],
+};
+```
+```javascript
+// bad
+const hero = {
+  firstName: 'Dana',
+  lastName: 'Scully'
+};
 
-    const heroes = [
-      'Batman',
-      'Superman'
-    ];
+const heroes = [
+  'Batman',
+  'Superman'
+];
 
-    // good
-    const hero = {
-      firstName: 'Dana',
-      lastName: 'Scully',
-    };
+// good
+const hero = {
+  firstName: 'Dana',
+  lastName: 'Scully',
+};
 
-    const heroes = [
-      'Batman',
-      'Superman',
-    ];
+const heroes = [
+  'Batman',
+  'Superman',
+];
 
-    // etc
-    ```
+// etc
+```
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Naming Conventions
 
-  <a name="naming--descriptive"></a><a name="22.1"></a>
-  - [Descriptive](#naming--descriptive): Avoid single letter names. Be descriptive with your naming. eslint: [`id-length`](http://eslint.org/docs/rules/id-length)
+<a name="naming--descriptive"></a><a name="22.1"></a>
+- [Descriptive](#naming--descriptive): Avoid single letter names. Be descriptive with your naming. eslint: [`id-length`](http://eslint.org/docs/rules/id-length)
 
-    ```javascript
-    // bad
-    function q() {
-      // ...stuff...
-    }
+```javascript
+// bad
+function q() {
+  // ...stuff...
+}
 
-    // good
-    function query() {
-      // ..stuff..
-    }
-    ```
+// good
+function query() {
+  // ..stuff..
+}
+```
 
-  <a name="naming--camelCase"></a><a name="22.2"></a>
-  - [camelCase](#naming--camelCase): Use camelCase when naming objects, functions, and instances. eslint: [`camelcase`](http://eslint.org/docs/rules/camelcase.html) jscs: [`requireCamelCaseOrUpperCaseIdentifiers`](http://jscs.info/rule/requireCamelCaseOrUpperCaseIdentifiers)
+<a name="naming--camelCase"></a><a name="22.2"></a>
+- [camelCase](#naming--camelCase): Use camelCase when naming objects, functions, and instances. eslint: [`camelcase`](http://eslint.org/docs/rules/camelcase.html) jscs: [`requireCamelCaseOrUpperCaseIdentifiers`](http://jscs.info/rule/requireCamelCaseOrUpperCaseIdentifiers)
 
-    ```javascript
-    // bad
-    const OBJEcttsssss = {};
-    const this_is_my_object = {};
-    function c() {}
+```javascript
+// bad
+const OBJEcttsssss = {};
+const this_is_my_object = {};
+function c() {}
 
-    // good
-    const thisIsMyObject = {};
-    function thisIsMyFunction() {}
-    ```
+// good
+const thisIsMyObject = {};
+function thisIsMyFunction() {}
+```
 
-  <a name="naming--PascalCase"></a><a name="22.3"></a>
-  - [PascalCase](#naming--PascalCase): Use PascalCase only when naming constructors or classes. eslint: [`new-cap`](http://eslint.org/docs/rules/new-cap.html) jscs: [`requireCapitalizedConstructors`](http://jscs.info/rule/requireCapitalizedConstructors)
+<a name="naming--PascalCase"></a><a name="22.3"></a>
+- [PascalCase](#naming--PascalCase): Use PascalCase only when naming constructors or classes. eslint: [`new-cap`](http://eslint.org/docs/rules/new-cap.html) jscs: [`requireCapitalizedConstructors`](http://jscs.info/rule/requireCapitalizedConstructors)
 
-    ```javascript
-    // bad
-    function user(options) {
-      this.name = options.name;
-    }
+```javascript
+// bad
+function user(options) {
+  this.name = options.name;
+}
 
-    const bad = new user({
-      name: 'nope',
-    });
+const bad = new user({
+  name: 'nope',
+});
 
-    // good
-    class User {
-      constructor(options) {
-        this.name = options.name;
-      }
-    }
+// good
+class User {
+  constructor(options) {
+    this.name = options.name;
+  }
+}
 
-    const good = new User({
-      name: 'yup',
-    });
-    ```
+const good = new User({
+  name: 'yup',
+});
+```
 
-  <a name="naming--leading-underscore"></a><a name="22.4"></a>
-  - [Leading underscores](#naming--leading-underscore): Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
+<a name="naming--leading-underscore"></a><a name="22.4"></a>
+- [Leading underscores](#naming--leading-underscore): Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
 
-    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present; a closure.
+> Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won't count as breaking, or that tests aren't needed. tl;dr: if you want something to be “private”, it must not be observably present; a closure.
 
-    ```javascript
-    // bad
-    this.__firstName__ = 'Panda';
-    this.firstName_ = 'Panda';
-    this._firstName = 'Panda';
+```javascript
+// bad
+this.__firstName__ = 'Panda';
+this.firstName_ = 'Panda';
+this._firstName = 'Panda';
 
-    // good
-    this.firstName = 'Panda';
+// good
+this.firstName = 'Panda';
 
-    function closure() {
-      const privateFunction = () => {
-        //...
-      }
-    }
-    ```
+function closure() {
+  const privateFunction = () => {
+    //...
+  }
+}
+```
 
-  <a name="naming--self-this"></a><a name="22.5"></a>
-  - [self this](#naming--self-this): Don't save references to `this`. Use arrow functions or [Function#bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). jscs: [`disallowNodeTypes`](http://jscs.info/rule/disallowNodeTypes)
+<a name="naming--self-this"></a><a name="22.5"></a>
+- [self this](#naming--self-this): Don't save references to `this`. Use arrow functions or [Function#bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). jscs: [`disallowNodeTypes`](http://jscs.info/rule/disallowNodeTypes)
 
-    ```javascript
-    // bad
-    function foo() {
-      const self = this;
-      return function () {
-        console.log(self);
-      };
-    }
+```javascript
+// bad
+function foo() {
+  const self = this;
+  return function () {
+    console.log(self);
+  };
+}
 
-    // bad
-    function foo() {
-      const that = this;
-      return function () {
-        console.log(that);
-      };
-    }
+// bad
+function foo() {
+  const that = this;
+  return function () {
+    console.log(that);
+  };
+}
 
-    // good
-    function foo() {
-      return () => {
-        console.log(this);
-      };
-    }
-    ```
+// good
+function foo() {
+  return () => {
+    console.log(this);
+  };
+}
+```
 
-  <a name="naming--filename-matches-export"></a><a name="22.6"></a>
-  - [Exports and filenames](#naming--filename-matches-export): A base filename should exactly match the name of its default export.
+<a name="naming--filename-matches-export"></a><a name="22.6"></a>
+- [Exports and filenames](#naming--filename-matches-export): A base filename should exactly match the name of its default export.
 
-    ```javascript
-    // file 1 contents
-    class CheckBox {
-      // ...
-    }
-    export default CheckBox;
+```javascript
+// file 1 contents
+class CheckBox {
+  // ...
+}
+export default CheckBox;
 
-    // file 2 contents
-    export default function fortyTwo() { return 42; }
+// file 2 contents
+export default function fortyTwo() { return 42; }
 
-    // file 3 contents
-    export default function insideDirectory() {}
+// file 3 contents
+export default function insideDirectory() {}
 
-    // in some other file
-    // bad
-    import CheckBox from './checkBox'; // PascalCase import/export, camelCase filename
-    import FortyTwo from './FortyTwo'; // PascalCase import/filename, camelCase export
-    import InsideDirectory from './InsideDirectory'; // PascalCase import/filename, camelCase export
+// in some other file
+// bad
+import CheckBox from './checkBox'; // PascalCase import/export, camelCase filename
+import FortyTwo from './FortyTwo'; // PascalCase import/filename, camelCase export
+import InsideDirectory from './InsideDirectory'; // PascalCase import/filename, camelCase export
 
-    // bad
-    import CheckBox from './check_box'; // PascalCase import/export, snake_case filename
-    import forty_two from './forty_two'; // snake_case import/filename, camelCase export
-    import inside_directory from './inside_directory'; // snake_case import, camelCase export
-    import index from './inside_directory/index'; // requiring the index file explicitly
-    import insideDirectory from './insideDirectory/index'; // requiring the index file explicitly
+// bad
+import CheckBox from './check_box'; // PascalCase import/export, snake_case filename
+import forty_two from './forty_two'; // snake_case import/filename, camelCase export
+import inside_directory from './inside_directory'; // snake_case import, camelCase export
+import index from './inside_directory/index'; // requiring the index file explicitly
+import insideDirectory from './insideDirectory/index'; // requiring the index file explicitly
 
-    // good
-    import CheckBox from './CheckBox'; // PascalCase export/import/filename
-    import fortyTwo from './fortyTwo'; // camelCase export/import/filename
-    import insideDirectory from './insideDirectory'; // camelCase export/import/directory name/implicit "index"
-    // ^ supports both insideDirectory.js and insideDirectory/index.js
-    ```
+// good
+import CheckBox from './CheckBox'; // PascalCase export/import/filename
+import fortyTwo from './fortyTwo'; // camelCase export/import/filename
+import insideDirectory from './insideDirectory'; // camelCase export/import/directory name/implicit "index"
+// ^ supports both insideDirectory.js and insideDirectory/index.js
+```
 
-  <a name="naming--camelCase-default-export"></a><a name="22.7"></a>
-  - [camelCase default exports](#naming--camelCase-default-export): Use camelCase when you export-default a function. Your filename should be identical to your function's name.
+<a name="naming--camelCase-default-export"></a><a name="22.7"></a>
+- [camelCase default exports](#naming--camelCase-default-export): Use camelCase when you export-default a function. Your filename should be identical to your function's name.
 
-    ```javascript
-    function makeStyleGuide() {
-    }
+```javascript
+function makeStyleGuide() {
+}
 
-    export default makeStyleGuide;
-    ```
+export default makeStyleGuide;
+```
 
-  <a name="naming--PascalCase-singleton"></a><a name="22.8"></a>
-  - [PascalCase](#naming--PascalCase-singleton): Use PascalCase when you export a constructor / class / singleton / function library / bare object.
+<a name="naming--PascalCase-singleton"></a><a name="22.8"></a>
+- [PascalCase](#naming--PascalCase-singleton): Use PascalCase when you export a constructor / class / singleton / function library / bare object.
 
-    ```javascript
-    const DeliverooStyleGuide = {
-      es6: {
-      }
-    };
+```javascript
+const DeliverooStyleGuide = {
+  es6: {
+  }
+};
 
-    export default DeliverooStyleGuide;
-    ```
+export default DeliverooStyleGuide;
+```
 
 **[⬆ back to top](#table-of-contents)**
 
 ## Modules
 
-  <a name="modules--use-them"></a><a name="10.1"></a>
-  - [Imports over require](#modules--use-them): Always use modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
+<a name="modules--use-them"></a><a name="10.1"></a>
+- [Imports over require](#modules--use-them): Always use modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
 
-    > Why? Modules are the future, let's start using the future now.
+> Why? Modules are the future, let's start using the future now.
 
-    ```javascript
-    // bad
-    const DeliverooStyleGuide = require('./DeliverooStyleGuide');
-    module.exports = DeliverooStyleGuide.es6;
+```javascript
+// bad
+const DeliverooStyleGuide = require('./DeliverooStyleGuide');
+module.exports = DeliverooStyleGuide.es6;
 
-    // ok
-    import DeliverooStyleGuide from './DeliverooStyleGuide';
-    export default DeliverooStyleGuide.es6;
+// ok
+import DeliverooStyleGuide from './DeliverooStyleGuide';
+export default DeliverooStyleGuide.es6;
 
-    // best
-    import { es6 } from './DeliverooStyleGuide';
-    export default es6;
-    ```
+// best
+import { es6 } from './DeliverooStyleGuide';
+export default es6;
+```
 
-  <a name="modules--no-wildcard"></a><a name="10.2"></a>
-  - [Wildcards](#modules--no-wildcard): Do not use wildcard imports.
+<a name="modules--no-wildcard"></a><a name="10.2"></a>
+- [Wildcards](#modules--no-wildcard): Do not use wildcard imports.
 
-    > Why? This makes sure you have a single default export.
+> Why? This makes sure you have a single default export.
 
-    ```javascript
-    // bad
-    import * as DeliverooStyleGuide from './DeliverooStyleGuide';
+```javascript
+// bad
+import * as DeliverooStyleGuide from './DeliverooStyleGuide';
 
-    // good
-    import DeliverooStyleGuide from './DeliverooStyleGuide';
-    ```
+// good
+import DeliverooStyleGuide from './DeliverooStyleGuide';
+```
 
-  <a name="modules--no-export-from-import"></a><a name="10.3"></a>
-  - [No export from import](#modules--no-export-from-import): And do not export directly from an import.
+<a name="modules--no-export-from-import"></a><a name="10.3"></a>
+- [No export from import](#modules--no-export-from-import): And do not export directly from an import.
 
-    > Why? Although the one-liner is concise, having one clear way to import and one clear way to export makes things consistent.
+> Why? Although the one-liner is concise, having one clear way to import and one clear way to export makes things consistent.
 
-    ```javascript
-    // bad
-    // filename es6.js
-    export { es6 as default } from './DeliverooStyleGuide';
+```javascript
+// bad
+// filename es6.js
+export { es6 as default } from './DeliverooStyleGuide';
 
-    // good
-    // filename es6.js
-    import { es6 } from './DeliverooStyleGuide';
-    export default es6;
-    ```
+// good
+// filename es6.js
+import { es6 } from './DeliverooStyleGuide';
+export default es6;
+```
 
-  <a name="modules--no-duplicate-imports"></a>
-  - [No dupe imports](#modules--no-duplicate-imports): Only import from a path in one place.
- eslint: [`no-duplicate-imports`](http://eslint.org/docs/rules/no-duplicate-imports)
-    > Why? Having multiple lines that import from the same path can make code harder to maintain.
+<a name="modules--no-duplicate-imports"></a>
+- [No dupe imports](#modules--no-duplicate-imports): Only import from a path in one place.
+eslint: [`no-duplicate-imports`](http://eslint.org/docs/rules/no-duplicate-imports)
+> Why? Having multiple lines that import from the same path can make code harder to maintain.
 
-    ```javascript
-    // bad
-    import foo from 'foo';
-    // … some other imports … //
-    import { named1, named2 } from 'foo';
+```javascript
+// bad
+import foo from 'foo';
+// … some other imports … //
+import { named1, named2 } from 'foo';
 
-    // good
-    import foo, { named1, named2 } from 'foo';
+// good
+import foo, { named1, named2 } from 'foo';
 
-    // good
-    import foo, {
-      named1,
-      named2,
-    } from 'foo';
-    ```
+// good
+import foo, {
+  named1,
+  named2,
+} from 'foo';
+```
 
-  <a name="modules--no-mutable-exports"></a>
-  - [Immutable exports](#modules--no-mutable-exports): Do not export mutable bindings.
- eslint: [`import/no-mutable-exports`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
-    > Why? Mutation should be avoided in general, but in particular when exporting mutable bindings. While this technique may be needed for some special cases, in general, only constant references should be exported.
+<a name="modules--no-mutable-exports"></a>
+- [Immutable exports](#modules--no-mutable-exports): Do not export mutable bindings.
+eslint: [`import/no-mutable-exports`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
+> Why? Mutation should be avoided in general, but in particular when exporting mutable bindings. While this technique may be needed for some special cases, in general, only constant references should be exported.
 
-    ```javascript
-    // bad
-    let foo = 3;
-    export { foo }
+```javascript
+// bad
+let foo = 3;
+export { foo }
 
-    // good
-    const foo = 3;
-    export { foo }
-    ```
+// good
+const foo = 3;
+export { foo }
+```
 
-  <a name="modules--prefer-default-export"></a>
-  - [Default exports](#modules--prefer-default-export): In modules with a single export, prefer default export over named export.
- eslint: [`import/prefer-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
+<a name="modules--prefer-default-export"></a>
+- [Default exports](#modules--prefer-default-export): In modules with a single export, prefer default export over named export.
+eslint: [`import/prefer-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
 
-    ```javascript
-    // bad
-    export function foo() {}
+```javascript
+// bad
+export function foo() {}
 
-    // good
-    export default function foo() {}
-    ```
+// good
+export default function foo() {}
+```
 
-  <a name="modules--imports-first"></a>
-  - [Imports first](#modules--imports-first): Put all `import`s above non-import statements.
- eslint: [`import/imports-first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md)
-    > Why? Since `import`s are hoisted, keeping them all at the top prevents surprising behavior.
+<a name="modules--imports-first"></a>
+- [Imports first](#modules--imports-first): Put all `import`s above non-import statements.
+eslint: [`import/imports-first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md)
+> Why? Since `import`s are hoisted, keeping them all at the top prevents surprising behavior.
 
-    ```javascript
-    // bad
-    import foo from 'foo';
-    foo.init();
+```javascript
+// bad
+import foo from 'foo';
+foo.init();
 
-    import bar from 'bar';
+import bar from 'bar';
 
-    // good
-    import foo from 'foo';
-    import bar from 'bar';
+// good
+import foo from 'foo';
+import bar from 'bar';
 
-    foo.init();
-    ```
+foo.init();
+```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/_guidelines/react.md
+++ b/_guidelines/react.md
@@ -12,52 +12,52 @@ title:      "React"
 
 ## Props
 
-  - Always use camelCase for prop names.
+- Always use camelCase for prop names.
 
-    ```jsx
-    // bad
-    <Foo
-      UserName="hello"
-      phone_number={12345678}
-    />
+```jsx
+// bad
+<Foo
+  UserName="hello"
+  phone_number={12345678}
+/>
 
-    // good
-    <Foo
-      userName="hello"
-      phoneNumber={12345678}
-    />
-    ```
+// good
+<Foo
+  userName="hello"
+  phoneNumber={12345678}
+/>
+```
 
-  - Omit the value of the prop when it is explicitly `true`. eslint: [`react/jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
+- Omit the value of the prop when it is explicitly `true`. eslint: [`react/jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
 
-    ```jsx
-    // bad
-    <Foo
-      hidden={true}
-    />
+```jsx
+// bad
+<Foo
+  hidden={true}
+/>
 
-    // good
-    <Foo
-      hidden
-    />
-    ```
+// good
+<Foo
+  hidden
+/>
+```
 
-  - Avoid using an array index as `key` prop, prefer a unique ID. ([why?](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318))
+- Avoid using an array index as `key` prop, prefer a unique ID. ([why?](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318))
 
-  ```jsx
-  // bad
-  {todos.map((todo, index) =>
-    <Todo
-      {...todo}
-      key={index}
-    />
-  )}
+```jsx
+// bad
+{todos.map((todo, index) =>
+  <Todo
+    {...todo}
+    key={index}
+  />
+)}
 
-  // good
-  {todos.map(todo => (
-    <Todo
-      {...todo}
-      key={todo.id}
-    />
-  ))}
-  ```
+// good
+{todos.map(todo => (
+  <Todo
+    {...todo}
+    key={todo.id}
+  />
+))}
+```


### PR DESCRIPTION
The syntax highlighter github-pages uses to generate nicely-formatted code examples offline is `rouge`, rather than the _Github-Flavored Markdown_ we’re familiar with seeing in issues and the markdown previews on github itself. Unfortunately Rouge doesn’t recognise code blocks with language identifiers (e.g. ````javascript`) if they’ve been indented by a tab or four spaces. Similarly, any _non-code_ blocks indented in this way are assumed to be code, even if they’re not. This results in this kind of output:

![img](http://snap.kapowaz.net/hqkhd.png)

Fixing the indentation gives us the desired results:

![img](http://snap.kapowaz.net/8prgp.png)