### PR TITLE
API guidelines: fix for collections

### DIFF
--- a/_guidelines/api-design.md
+++ b/_guidelines/api-design.md
@@ -742,7 +742,7 @@ A collection representation
 In a collection representation, embedded representations _may_ be incomplete,
 but _should_ include at least a numeric `id` and the mandatory link to `self`.
 
-Example:
+Example: standard collection response
 
 ```yml
 #> GET /hotels?checkin=2016-01-02&checkout=2016-01-09
@@ -751,18 +751,44 @@ page:     1
 per_page: 10
 total:    153277
 _links:
-  self:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=1"
-  prev:   null
-  next:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=2"
+  self:   
+    href:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=1"
+  prev:     null
+  next:   
+    href:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=2"
+  hotels:
+    - href: "/hotels/1"
+    - href: "/hotels/2"
+```
+
+Example: collection response with partial embedded resources
+
+```yml
+#> GET /hotels?checkin=2016-01-02&checkout=2016-01-09
+#< HTTP/1.0 200 OK
+page:     1
+per_page: 10
+total:    153277
+_links:
+  self:   
+    href:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=1"
+  prev:     null
+  next:   
+    href:   "/hotels?checkin=2016-01-02&checkout=2016-01-09&page=2"
+  hotels:
+    - href: "/hotels/1"
+    - href: "/hotels/2"
 _embedded:
   hotels:
     - id: 1
       _links:
-        self: "/hotels/1"
+        self: 
+          href:   "/hotels/1"
     ...
     - id: 10
       _links:
-        self: "/hotels/2"
+        self: 
+          href:   "/hotels/2"
 ```
 
 

--- a/_guidelines/api-design.md
+++ b/_guidelines/api-design.md
@@ -724,8 +724,8 @@ A collection GET endpoint _should_ be of one of the forms:
 - `/{concept-plural}`, e.g. `/hotels`
 - `/{parent}/{id}/{concept-plural}`, e.g. `/hotels/1234/photos`
 
-Such endpoints _must_ return a representation of the collection, and embed a
-list of (possibly partial) representations of some of the entities.
+Such endpoints _must_ return a representation of the collection. They _must_
+link to a (possibly empty) list of entities.
 
 _Rationale_:
 In domain terms, an index endpoint actually returns a _view_ on the _collection_
@@ -739,10 +739,7 @@ A collection representation
 - _should_ link to relations `next` and `prev` for pagination purposes;
 - _must_ include the properties `page`, `per_page`, `total`
 
-In a collection representation, embedded representations _may_ be incomplete,
-but _should_ include at least a numeric `id` and the mandatory link to `self`.
-
-Example: standard collection response
+Example:
 
 ```yml
 #> GET /hotels?checkin=2016-01-02&checkout=2016-01-09
@@ -761,7 +758,16 @@ _links:
     - href: "/hotels/2"
 ```
 
-Example: collection response with partial embedded resources
+
+Exceptionally, a collection representation, _may_ embedded representations of
+the linked resources, which _may_ be incomplete, but _must_ include at least a
+the mandatory link to `self`.
+
+Note that as for other use cases of `_embedded`, there should be a very robust
+reason to do so as it makes using the API more complex (partial representations,
+caching issues, etc).
+
+Example:
 
 ```yml
 #> GET /hotels?checkin=2016-01-02&checkout=2016-01-09


### PR DESCRIPTION
After chats with @gbonfant, @rfonglip, and @gregbeech, this corrects our example collection responses to:

- properly include links to the resources in the collection
- fix the links themselves (they were missing the `href` nesting)
- make it more obvious embedding should not be the norm 