### PR TITLE
Update format of guidelines & add descriptions

### DIFF
--- a/_guidelines/00-meta.md
+++ b/_guidelines/00-meta.md
@@ -1,9 +1,17 @@
 ---
-title:      "Meta"
+layout:     guidelines
+title:      "Meta-Guidelines"
 subtitle:   "Guidelines about guidelines"
+collection: guidelines
 ---
 
-#### Why we do this
+## Table of Contents
+{:.no_toc}
+
+1. Automatic Table of Contents Here
+{:toc}
+
+### Why we do this
 
 In a large team, building and maintaining multiple software assets, code
 consistency and acquired good practices matter.
@@ -12,7 +20,7 @@ Having solid guidelines is a pillar of maintainable software, much like
 continuous integration and a solid review process.
 
 
-#### Using guidelines
+### Using guidelines
 
 We recommend that all new starters read the guidelines documents relevant to the
 technologies they'll be using.
@@ -30,7 +38,7 @@ Note that the code in a pull request should follow the guidelines, _even_ if the
 author of the PR isn't the author of the original code. This is how old code
 gets updated over time.
 
-#### Changing guidelines
+### Changing guidelines
 
 Coding guidelines are curated collectively.
 This is the process we choose to follow:
@@ -53,7 +61,7 @@ guidelines for _new_ code, and strive to bring _old_ code in compliance - over
 time, as mentioned above. It is not recommended to upgrade old code in bulk, as
 this can be much more difficult to test/QA properly.
 
-#### Notifying about changes
+### Notifying about changes
 
 When a pull request is issued, the `#geeks` and `#tech-leads` channels in Slack
 are pinged automatically (through Zapier).
@@ -62,12 +70,67 @@ Nothing is (currently) done automatically when a pull request is merged, though,
 so you may want to broadcast in `#geeks` or via email as appropriate.
 
 
-#### Formatting guidelines
+### Formatting guidelines
 
-This site uses Jekyll and Github Pages, so Markdown is favoured.
-
-Use of emoji is encouraged!
+This site uses Jekyll and Github Pages, so Markdown is favoured. Jekyll uses
+[Kramdown][kramdown]-flavoured Markdown, so you may need to change your formatting
+slightly from Github-flavoured Markdown.
 
 You may respect an 80 column limit in the source to facilitate reviews, or not
 if you're content with Github wrapping lines for you.
 
+Use of emoji is encouraged! :grin: The same aliases as standard Slack emoji work.
+
+#### Adding a Table of Contents
+
+Kramdown can generate a Table of Contents for you automatically, using the 
+headings in your document as the items in the list. To use this, add the 
+following Markdown to the top of your document (immediately after the Front 
+Matter):
+
+```markdown
+## Table of Contents
+{:.no_toc}
+
+1. Automatic Table of Contents Here
+{:toc}
+```
+
+This will add a heading with the text _Table of Contents_ which _doesn’t_ 
+appear in the table of contents itself, followed by the TOC. The list item
+shown here will be automatically replaced with the TOC contents.
+
+#### Adding footnotes
+
+When adding inline references to external sites, you may wish to use footnotes
+to capture these, which are then displayed at the bottom of the guidelines
+page. To use these, simply create a reference to the footnote in the location
+you wish the link to appear, e.g.
+
+```markdown
+The name _Ruby_ was chosen in part because it is Yukihiro Matsumoto’s birthstone[^ruby].
+```
+
+You can then follow this in a suitable location (ideally close by) with the 
+actual footnote reference. This can actually be any valid Markdown, but for
+simplicity’s sake, you may just want to use a link to the reference source:
+
+```markdown
+[^ruby]: [The name "Ruby"](https://en.wikipedia.org/wiki/Ruby_(programming_language)#The_name_.22Ruby.22)
+```
+
+#### Adding code samples
+
+Markdown supports several different types of indicating code blocks, but to
+take advantage of syntax highlighting, use the following format (without any
+indentation):
+
+```markdown
+  ```ruby
+  def what?
+    42
+  end
+  ```
+```
+
+[kramdown]: http://kramdown.gettalong.org/documentation.html

--- a/_guidelines/active-record.md
+++ b/_guidelines/active-record.md
@@ -1,18 +1,23 @@
 ---
+layout:     guidelines
 title:      "Active Record"
+subtitle:   "Guidelines for fast & reusable Active Record"
+collection: guidelines
 ---
 
+## Table of Contents
+{:.no_toc}
 
-My mom told me that ActiveRecord doesn't scale!
-Fortunately, here comes the...
+1. Automatic Table of Contents Here
+{:toc}
 
-# Guidelines for fast & reusable ActiveRecord
+You may have previously heard somebody say something like this:
 
-This is a smell of bad design:
+> *I need to write a custom SQL query to do this!*
 
-> *I need to write a custom SQL query to do this !*
->
-> — No one, ever
+or:
+
+> *I’ve heard that ActiveRecord doesn't scale…*
 
 **This guide** is here to **help you** write ActiveRecord (or any ORM code,
 really) that lets your app **scale** with good performance and without
@@ -47,7 +52,6 @@ We make two exceptions to "logic in the database":
 The only case where your database will "do" something for you beyond storage is
 when counting, or otherwise aggregating persisted data. This is essentially for
 performance reasons.
-
 
 ### Controllers, views, presenters, decorators
 

--- a/_guidelines/git.md
+++ b/_guidelines/git.md
@@ -1,16 +1,15 @@
 ---
 layout:     guidelines
-title:      "Git / Source Control"
+title:      "Git & Source Control"
+subtitle:   "Guidelines for using Git source control"
 collection: guidelines
 ---
 
-# Deliveroo Git Usage Guide
-
-*A mostly reasonable approach to Git*
-
 ## Table of Contents
+{:.no_toc}
 
-  1. [Force Pushing](#force-pushing)
+1. Automatic Table of Contents Here
+{:toc}
 
 ## Force Pushing
 
@@ -22,8 +21,8 @@ When force pushing **always** use `--force-with-lease` to ensure there are no re
 
 Remember, when performing _destructive_ commands that effect remote: **Communication is key.**
 
-- [Force Pushing Master:](#force-pushing--master) **Nope.** This is something that should never be done by anyone. Master should always be protected from force pushing and this should **never** be removed. If you need to undo something that is in master **revert** commits that are causing you issues and pr them in.
-- [Force Pushing Your Own Branch:](#force-pushing--own-branch) **Sure.** If no one else is working on it and you created the branch then force push at will. If someone has come and asked you if they can add something to your branch then check with them *before* force pushing anything.
-- [Force Pushing Someone Else's Branch](#force-pushing--other-branch) **Sometimes.** Talk to them about this before modifying their branch to ensure you know the full situation before force pushing.
-- [Force Pushing a Merged Branch](#force-pushing--merged-branch) **Nope.** Force pushing a branch that has been merged to a branch that has a large exposure (for example staging or master) is not recommended. Merging to that branch again will be messy and problematic, and force pushing the branch with exposure will be even more so.
-- [Force Pushing to Remove Sensitive Data](#force-pushing--sensitive-data) **Sure.** If sensitive data has been pushed by accident (private keys, stats or other company secrets) force push in accordance with the other rules (where possible) to expunge them from git history. Know that **any** information pushed should be deemed compromised and that anyone with a checkout of the code may retain a copy on their machine and any third parties (Github, Travis etc) whom might have caching that keeps the data alive. Notify senior staff of the issue and coordinate with them to get it sorted.
+- [Force Pushing Master](#force-pushing--master): **Nope.** This is something that should never be done by anyone. Master should always be protected from force pushing and this should **never** be removed. If you need to undo something that is in master **revert** commits that are causing you issues and pr them in.
+- [Force Pushing Your Own Branch](#force-pushing--own-branch): **Sure.** If no one else is working on it and you created the branch then force push at will. If someone has come and asked you if they can add something to your branch then check with them *before* force pushing anything.
+- [Force Pushing Someone Else's Branch](#force-pushing--other-branch): **Sometimes.** Talk to them about this before modifying their branch to ensure you know the full situation before force pushing.
+- [Force Pushing a Merged Branch](#force-pushing--merged-branch): **Nope.** Force pushing a branch that has been merged to a branch that has a large exposure (for example staging or master) is not recommended. Merging to that branch again will be messy and problematic, and force pushing the branch with exposure will be even more so.
+- [Force Pushing to Remove Sensitive Data](#force-pushing--sensitive-data): **Sure.** If sensitive data has been pushed by accident (private keys, stats or other company secrets) force push in accordance with the other rules (where possible) to expunge them from git history. Know that **any** information pushed should be deemed compromised and that anyone with a checkout of the code may retain a copy on their machine and any third parties (Github, Travis etc) whom might have caching that keeps the data alive. Notify senior staff of the issue and coordinate with them to get it sorted.

--- a/_guidelines/java-android.md
+++ b/_guidelines/java-android.md
@@ -1,7 +1,7 @@
 ---
 layout:     guidelines
-title:      "CSS and SCSS"
-subtitle:   "Guidelines on writing CSS and SCSS"
+title:      "Java & Android"
+subtitle:   "Guidelines on developing for Android with Java"
 collection: guidelines
 ---
 
@@ -11,4 +11,4 @@ collection: guidelines
 1. Automatic Table of Contents Here
 {:toc}
 
-Empty for now
+Contents go here.

--- a/_guidelines/java.md
+++ b/_guidelines/java.md
@@ -1,9 +1,0 @@
----
-layout:     guidelines
-title:      "Java / Android"
-collection: guidelines
----
-
-
-Contents go here.
-

--- a/_guidelines/objective-c.md
+++ b/_guidelines/objective-c.md
@@ -1,10 +1,14 @@
 ---
 layout:     guidelines
-title:      "Objective C / iOS"
+title:      "Objective-C & iOS"
+subtitle:   "Guidelines on developing for iOS with Objective-C"
 collection: guidelines
 ---
 
+## Table of Contents
+{:.no_toc}
+
+1. Automatic Table of Contents Here
+{:toc}
 
 Contents go here.
-
-

--- a/_guidelines/react.md
+++ b/_guidelines/react.md
@@ -1,20 +1,21 @@
 ---
-title:      "React"
+layout:     guidelines
+title:      "React/JSX Style Guide"
+subtitle:   "A mostly reasonable approach to React and JSX"
+collection: guidelines
 ---
 
-
-# Deliveroo React/JSX Style Guide
-
-*A mostly reasonable approach to React and JSX*
-
 ## Table of Contents
-1. Props
+{:.no_toc}
+
+1. Automatic Table of Contents Here
+{:toc}
 
 ## Props
 
-- Always use camelCase for prop names.
+Always use camelCase for prop names.
 
-```jsx
+```
 // bad
 <Foo
   UserName="hello"
@@ -28,9 +29,9 @@ title:      "React"
 />
 ```
 
-- Omit the value of the prop when it is explicitly `true`. eslint: [`react/jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
+Omit the value of the prop when it is explicitly `true`. [^jsx-boolean-value]
 
-```jsx
+```
 // bad
 <Foo
   hidden={true}
@@ -42,9 +43,11 @@ title:      "React"
 />
 ```
 
-- Avoid using an array index as `key` prop, prefer a unique ID. ([why?](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318))
+[^jsx-boolean-value]: [ESLint: react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
 
-```jsx
+Avoid using an array index as `key` prop, prefer a unique ID: using the index as a key is an [anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).
+
+```
 // bad
 {todos.map((todo, index) =>
   <Todo

--- a/_guidelines/rspec.md
+++ b/_guidelines/rspec.md
@@ -1,7 +1,14 @@
 ---
-title:      "Rspec"
+layout:     guidelines
+title:      "RSpec"
+subtitle:   "Guidelines for writing Ruby tests with RSpec"
+collection: guidelines
 ---
 
+## Table of Contents
+{:.no_toc}
 
-Empty for now
+1. Automatic Table of Contents Here
+{:toc}
 
+Empty for now.

--- a/_guidelines/ruby.md
+++ b/_guidelines/ruby.md
@@ -1,7 +1,14 @@
 ---
 layout:     guidelines
-title:      "Ruby"
+title:      "Ruby Style Guide"
+subtitle:   "Guidelines for writing Ruby"
 collection: guidelines
 ---
 
-Contents go here.
+## Table of Contents
+{:.no_toc}
+
+1. Automatic Table of Contents Here
+{:toc}
+
+Empty for now.


### PR DESCRIPTION
These changes update the layout/formatting of the various guideline documents to bring them in line with what the new blog layout expects, including:

* Adding Front Matter descriptions/titles
* Correcting heading levels
* Adding Table of Contents identifiers
* Made code blocks consistently use the ``` block identifier instead of indentation
* General tidying up

I’ve also added some more detail about Markdown guidelines to the meta document which describes the kind of thing I’ve added with this PR, so that future guidelines can make use of them.