### PR TITLE
Add footnotes subheading to JS guidelines doc

### DIFF
--- a/_guidelines/javascript.md
+++ b/_guidelines/javascript.md
@@ -536,3 +536,5 @@ foo.init();
 This guide is taken in part from the following sources:
 
 * [https://github.com/airbnb/javascript](https://github.com/airbnb/javascript)
+
+## Footnotes


### PR DESCRIPTION
The JS guidelines doc has a bunch of footnotes, but no subheading indicating them as such, so they run into the preceding references subsection; adding a subheading (without content below) addresses this.