### PR TITLE
Highlight footnotes when linked to from article body

### DIFF
--- a/_sass/local/content.scss
+++ b/_sass/local/content.scss
@@ -378,8 +378,21 @@ article {
   div.footnotes {
     color: color(mackeral, 80%);
     
+    li {
+      padding: 5px;
+            
+      &:target {
+        background-color: color(aubergine, 10%);
+      } // article div.footnotes li:target
+      
+      p {
+        margin: 0;
+      } // article div.footnotes li p
+    } // article div.footnotes li
+    
     a.reversefootnote {
       border: none;
+      margin-left: 5px;
     } // article div.footnotes a.reversefootnote
   } // article div.footnotes
   


### PR DESCRIPTION
This change makes the specific footnote you’ve been taken to from within the body more obvious, a la Wikipedia.

![img](http://snap.kapowaz.net/qhu4u.png)