### PR TITLE
add pagination to articles page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,10 @@ gems:
    - jekyll-redirect-from
    - jekyll-sitemap
    - jekyll-feed
+   - jekyll-paginate
+
+paginate: 3
+paginate_path: "/articles/page:num/"
 
 collections:
   guidelines:

--- a/articles/index.html
+++ b/articles/index.html
@@ -5,7 +5,7 @@ layout: default
 <p class="tagline">Learn from our experience developing the Deliveroo product.</p>
 
 <section id="recent-posts" class="all">
-  {% for _page in site.posts %}
+  {% for _page in paginator.posts %}
     <div class="post recent">
       <h3><a href="{{ site.baseurl }}{{ _page.url }}">{{ _page.title }}</a></h3>
       <p class="byline">{% include byline.html author=_page.author date=_page.date %}</p>
@@ -14,8 +14,23 @@ layout: default
       </blockquote>
       <p><a href="{{ _page.url }}" title="{{ _page.title }}">Read more…</a></p>
     </div>
-    {% unless forloop.index == site.posts.size %}
+    {% unless forloop.index == paginator.posts.size %}
       <hr>
     {% endunless %}
   {% endfor %}
 </section>
+{% if paginator.total_pages > 1 %}
+  <section class="pagination">
+    {% if paginator.previous_page %}
+      <a href="{{ paginator.previous_page_path }}" class="previous">Previous</a>
+    {% else %}
+      <span class="previous">Previous</span>
+    {% endif %}
+    <span class="page_number">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
+    {% if paginator.next_page %}
+      <a href="{{ paginator.next_page_path }}" class="next">Next</a>
+    {% else %}
+      <span class="next">Next</span>
+    {% endif %}
+  </section>
+{% endif %}


### PR DESCRIPTION
Hi,
this adds a simple pagination to the `/articles` page as it was mentioned in #58 via `jekyll-paginate` which is already installed on github pages.

<img width="1397" alt="screen shot 2016-10-08 at 17 00 17" src="https://cloud.githubusercontent.com/assets/570608/19214025/93f009a0-8d7a-11e6-8145-67bb781f0046.png">
