### PR TITLE
Improve font sizes of code within headings/TOC

### DIFF
--- a/_sass/base/_default.scss
+++ b/_sass/base/_default.scss
@@ -33,6 +33,19 @@ a {
   } // @external-href('deliveroo.engineering') a
 } // a
 
+code, kbd, pre, samp {
+  font-family: $monospace-font;
+}
+
+code {
+  font-size: font-size(small-body);
+  
+  &.highlighter-rouge {
+    background-color: color(anchovy, 20%);
+    padding: 2px;
+  }
+}
+
 h1, h2, h3, h4 {
   font-family: $title-font;
   font-weight: 600;
@@ -51,18 +64,34 @@ h2 {
   font-family: $title-font;
   font-weight: 600;
   font-size: font-size(medium-heading);
+  
+  code {
+    font-size: font-size(small-heading);
+  }
 }
 
 h3 {
   font-size: font-size(small-heading);
+  
+  code {
+    font-size: font-size(smallish-heading);
+  }
 }
 
 h4 {
   font-size: font-size(smallish-heading);
+  
+  code {
+    font-size: font-size(extra-small-heading);
+  }
 }
 
 h5, h6 {
   font-size: font-size(extra-small-heading);
+  
+  code {
+    font-size: font-size(extra-small-heading);
+  }
 }
 
 h2, h3, h4 {
@@ -80,10 +109,6 @@ hr {
   border-style: solid;
   border-color: color(anchovy, 40%);
   margin: 2em 0;
-}
-
-code, kbd, pre, samp {
-  font-family: $monospace-font;
 }
 
 ul, ol {

--- a/_sass/layout/content.scss
+++ b/_sass/layout/content.scss
@@ -12,15 +12,6 @@ body {
     font-size: font-size(medium-body);
     line-height: 1.5;
     
-    code {
-      font-size: font-size(small-body);
-      
-      &.highlighter-rouge {
-        background-color: color(anchovy, 20%);
-        padding: 2px;
-      } // body main code.highlighter-rouge
-    } // body main code
-    
     > h1,
     > h2,
     > p,
@@ -541,4 +532,8 @@ ol#markdown-toc {
       text-align: right;
     } // ol#markdown-toc li:before
   } // ol#markdown-toc li
+  
+  code {
+    font-size: font-size(smallest-body);
+  } // ol#markdown-toc code
 } // ol#markdown-toc


### PR DESCRIPTION
Compared to both Stratos and Adelle Sans, monospace fonts seem a little large; this PR improves (and is more explicit about) font sizes for these whenever `<code>` occurs inline within headings or the table of contents.

Example:

![img](http://snap.kapowaz.net/nc3up.png)