### PR TITLE
Add preamble to Ruby style guide

### DIFF
--- a/_guidelines/ruby.md
+++ b/_guidelines/ruby.md
@@ -11,4 +11,21 @@ collection: guidelines
 1. Automatic Table of Contents Here
 {:toc}
 
-Empty for now.
+## About the style guide
+
+This Ruby style guide recommends best practices so that real-world Ruby
+programmers can write code that can be maintained by other real-world Ruby
+programmers. A style guide that reflects real-world usage gets used, and a
+style guide that holds to an ideal that has been rejected by the people it is
+supposed to help risks not getting used at all &ndash; no matter how good it
+is.
+
+This guide is largely based upon Bozhidar Batsov’s 
+[Ruby Style Guide][ruby-style-guide], based on feedback and suggestions from 
+members of the Ruby community and various highly regarded Ruby programming 
+resources, such as Programming Ruby 1.9[^programming-ruby] and 
+The Ruby Programming Language[^the-ruby-programming-language].
+
+[ruby-style-guide]: https://github.com/bbatsov/ruby-style-guide
+[^programming-ruby]: [Programming Ruby 1.9](http://pragprog.com/book/ruby4/programming-ruby-1-9-2-0)
+[^the-ruby-programming-language]: [The Ruby Programming Language](http://www.amazon.com/Ruby-Programming-Language-David-Flanagan/dp/0596516177)


### PR DESCRIPTION
This PR adds a simple preamble to the Ruby style guide based around the one used in @bbatsov’s [guide](https://github.com/deliveroo/deliveroo.engineering/blob/master/ruby.md) which is being used as a basis for our own Ruby style guide.