### PR TITLE
Fix typo with footnote syntax.

### DIFF
--- a/_guidelines/javascript.md
+++ b/_guidelines/javascript.md
@@ -499,7 +499,7 @@ export { foo }
 ### Default exports
 {: #modules-default-exports}
 
-In modules with a single export, prefer default export over named export ^[prefer-default-export].
+In modules with a single export, prefer default export over named export [^prefer-default-export].
 
 ```javascript
 // bad


### PR DESCRIPTION
Fix broken markdown footnote syntax with the caret outside the brackets (oops).