### PR TITLE
Improve typography layout

### DIFF
--- a/_sass/layout/content.scss
+++ b/_sass/layout/content.scss
@@ -10,17 +10,17 @@ body {
   main {
     padding: 50px 10px;
     font-size: font-size(medium-body);
-    line-height: 1.5;
+    line-height: 1.8;
     
     > h1,
     > h2,
     > p,
     > section {
-      @include auto-width(desktop_larger);
+      @include auto-width(desktop_medium);
     } // body main > {h1, h2, p, section}
     
     > hr {
-      @include auto-width(desktop_larger, $vertical-margins: 2em);
+      @include auto-width(desktop_medium, $vertical-margins: 2em);
     } // body main > hr
     
     > h1 {
@@ -90,7 +90,7 @@ img.portrait {
 $post-gutter: 40px;
 
 section {
-  @include auto-width(desktop_larger);
+  @include auto-width(desktop_medium);
 
   & + h2 {
     margin-top: 50px;


### PR DESCRIPTION
After feedback from @phuly I’ve made some minor tweaks to improve the typography across the engineering site:

* Increased line height to 1.8
* Decreased the maximum container width for the homepage (reducing the maximum line length as a result):

![google chromescreensnapz048](https://cloud.githubusercontent.com/assets/25730/20765454/4cc022ac-b72a-11e6-85f9-a13e06dc16c5.png)
