### PR TITLE
Fix excerpt display on Julien’s post

### DIFF
--- a/_posts/2017-01-19-optimising-membership-queries.md
+++ b/_posts/2017-01-19-optimising-membership-queries.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Optimising Redis storage, part two"
 author: "Julien Letessier"
-exerpt: >
+excerpt: >
   Counting unique users, checking if a credit card has already been used, or
   checking if this is a mobile user's first visit ever — all of these require
   maintaining a large set of fingerprints (unique visitor ID, card fingerprint,


### PR DESCRIPTION
# What

This fixes display of the excerpt on Julien's blog post. 

As this branch was created before the code-wide spelling fix for excerpt, Julien's post is not correctly displaying his intended excerpt text and instead duplicating the first para of the post's body text.

# Screenshots

### Before:

<img width="1120" alt="screen shot 2017-01-20 at 11 52 55" src="https://cloud.githubusercontent.com/assets/574526/22148609/016f703c-df07-11e6-972d-f828c6974af9.png">


<img width="1046" alt="screen shot 2017-01-20 at 11 52 00" src="https://cloud.githubusercontent.com/assets/574526/22148597/f21afb42-df06-11e6-9f3b-e216db70641a.png">



### After:

<img width="1160" alt="screen shot 2017-01-20 at 11 53 24" src="https://cloud.githubusercontent.com/assets/574526/22148621/1236a584-df07-11e6-8545-8e5da5c18611.png">

<img width="995" alt="screen shot 2017-01-20 at 11 52 18" src="https://cloud.githubusercontent.com/assets/574526/22148633/21cb0f26-df07-11e6-9520-77e2d70d5ce1.png">
