### PR TITLE
Add opengraph metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 .tm_properties
 .DS_Store
 .ruby-gemset
+tmp

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+group :jekyll_plugins do
+  gem 'github-pages', versions['github-pages']
+  gem 'jekyll-contentblocks'
+end
 
 # Set us up to reload pages interactively
 gem 'guard-jekyll-plus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
       jekyll (~> 3.0)
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
+    jekyll-contentblocks (1.2.0)
+      jekyll
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
     jekyll-feed (0.8.0)
@@ -238,6 +240,7 @@ DEPENDENCIES
   github-pages (= 119)
   guard-jekyll-plus
   guard-livereload
+  jekyll-contentblocks
   json
 
 RUBY VERSION

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,12 +4,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_newlines }}{% endif %}">
+  {% assign canonical_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="{{site.url}}/images/logo_engineering.svg">
+  <meta property="og:image:width" content="735">
+  <meta property="og:image:height" content="100">
+  <meta property="og:image:type" content="image/svg">
+  {% contentblock meta %}
   <script src="https://use.typekit.net/qxo7ukw.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ canonical_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <script type="text/javascript" src="/javascript/anchor.min.js" async></script>
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.slim.min.js" async></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns#">
   {% include head.html %}
   <body>
     {% include header.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,6 +8,13 @@ layout: default
   {% endif %}
 {% endfor %}
 
+{% contentfor meta %}
+  <meta property="og:type" content="article">
+  <meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%d" }}">
+  <meta property="article:author" content="{{ site.url }}/authors/{{ author.name | slugify }}">
+  <meta property="article:section" content="Engineering Articles">
+{% endcontentfor %}
+
 <article>
   <header>
 


### PR DESCRIPTION
This PR adds opengraph metadata to the site, both for generic pages and with additional metadata for article pages:

![img](http://snap.kapowaz.net/dodym.png)

_(N.B. the `localhost:4000` examples you see here come from `site.url`, so this will be correct in production)_