### PR TITLE
Add opengraph metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 .tm_properties
 .DS_Store
 .ruby-gemset
+tmp

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,12 +4,33 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_newlines }}{% endif %}">
+  {% assign canonical_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+  <meta property="og:url" content="{{ canonical_url }}">
+  <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+  <meta property="og:image" content="{{site.url}}/images/logo_engineering.svg">
+  <meta property="og:image:width" content="735">
+  <meta property="og:image:height" content="100">
+  <meta property="og:image:type" content="image/svg">
+  
+  {% if page.layout == 'post' %}
+    {% for author in site.authors %}
+      {% if author.name == page.author %}
+        {% assign author = author %}
+      {% endif %}
+    {% endfor %}
+    <meta property="og:type" content="article">
+    <meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%d" }}">
+    <meta property="article:author" content="{{ site.url }}/authors/{{ author.name | slugify }}">
+    <meta property="article:section" content="Engineering Articles">
+  {% else %}
+    <meta property="og:type" content="website">
+  {% endif %}
+  
   <script src="https://use.typekit.net/qxo7ukw.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ canonical_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <script type="text/javascript" src="/javascript/anchor.min.js" async></script>
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.slim.min.js" async></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns#">
   {% include head.html %}
   <body>
     {% include header.html %}


### PR DESCRIPTION
This re-adds the metadata added in #118 that relied upon the unsupported `jekyll-contentblocks` plugin.

![img](https://camo.githubusercontent.com/87efb293b385daf04f217a274d2ef9593be23851/687474703a2f2f736e61702e6b61706f77617a2e6e65742f646f64796d2e706e67)

This solution is somewhat less elegant (it doesn’t allow arbitrary metadata to be set on a per-layout basis), but it works for the metadata we most need at the moment.