### PR TITLE
Guidelines/active-record Fix query object documented method name

### DIFF
--- a/_guidelines/active-record.md
+++ b/_guidelines/active-record.md
@@ -459,7 +459,7 @@ your query. More than three? Things will :boom: blow up.
 In particular, multiple joins are a symptom of over-normalized data modeling.
 
 If that isn't enough: precalculate, use caching, and **do your math in Ruby** as
-described in the revious section.
+described in the previous section.
 Your app code can scale very well (possibly through scheduled jobs), the
 database cannot.
 

--- a/_guidelines/active-record.md
+++ b/_guidelines/active-record.md
@@ -32,7 +32,7 @@ defend it!
 Layering and **separation of concerns** are overarching principles here.  There
 should be a clear separation between your **database** and your **application**:
 the former is there to persist data, period. When you put something in, it
-should come out exactly as is, and pulling it out should be reasonably simple. 
+should come out exactly as is, and pulling it out should be reasonably simple.
 
 In particular your database should not have any logic: all the (business) rules
 should be in your application. This means that triggers, stored procedures
@@ -79,7 +79,7 @@ Okay:
 ```ruby
 @users = current_user.posts.where(created_at: 1.year.ago .. Time.current)
 ```
-    
+
 Bad:
 
 ```ruby
@@ -101,7 +101,7 @@ Worse:
 Models should not contain any SQL queries.
 
 They can, however, exceptionally contain SQL _expressions_ in the form of
-`where` conditions for instance. 
+`where` conditions for instance.
 
 Using [Arel](https://github.com/rails/arel) to express conditions can also be
 used; bear in mind Arel is a somewhat private API that changes between Rails
@@ -119,7 +119,7 @@ scope :created_after, -> { |timestamp| where('created_at > ?', timestamp) }
 Better (no SQL, no issue with using the scope in joins):
 
 ```ruby
-scope :created_after, -> { |timestamp| 
+scope :created_after, -> { |timestamp|
   where self.class.arel_table[:created_at].gt timestamp
 }
 ```
@@ -152,7 +152,7 @@ Good:
 ```ruby
 scope :created_after, -> { |timestamp| ... }
 ```
-    
+
 Bad:
 
 ```ruby
@@ -168,7 +168,7 @@ possible.
 Scope parameters should be records, not IDs, wherever possible and not hurtful
 for performance.
 
-Good: `User.account_is(account)`, `User.created_after(date)` 
+Good: `User.account_is(account)`, `User.created_after(date)`
 
 Bad: `User.member_of(account)`, `User.recently_created(date)`,
 `User.account_id_is(account.id)`
@@ -331,7 +331,7 @@ PoEAA](http://www.martinfowler.com/eaaCatalog/queryObject.html), this is meant
 to encapsulate a query:
 
 - it is instantiated with a number of criteria
-- it has an `#execute` method that either has a side effect, or iterates over
+- it has a `#call` method that either has a side effect, or iterates over
   query results
 
 This is the only type of classes where `ActiveRecord::Base#find_by_sql` or
@@ -347,7 +347,7 @@ class User::RecentlyCreatedFinder
     @account = account or raise ArgumentError
     @timestamp = timestamp || 1.week.ago
   end
-  
+
   def call
     ids = User.connection.select_values(sanitize([%{
       SELECT id FROM users
@@ -369,7 +369,7 @@ class User::RecentlyCreatedFinder
     @account = account or raise ArgumentError
     @timestamp = timestamp || 1.week.ago
   end
-  
+
   def call
     User.
     where(account_id: @account.id).
@@ -499,7 +499,7 @@ restaurants = Restaurant.
   joins('RIGHT JOIN orders ON orders.restaurant_id = restaurants.id').
   joins('LEFT JOIN ratings ON ratings.order_id = orders.id').
   where(
-    order: { 
+    order: {
       user_id: current_user, status: 'delivered',
     },
     ratings: {
@@ -532,7 +532,7 @@ have to.
 # Good:
 User.paginate(page:1, per_page:10)
 User.limit(10)
-    
+
 # Fine:
 User.find_in_batches { |batch| ... }
 


### PR DESCRIPTION
Small fix : The Query Object method used in examples is `#call` while the documentation just above that used `#execute`.

Also a small typo and automatic end-of-line whitespace removal.