### PR TITLE
add `jekyll-seo-tag`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ DEPENDENCIES
   github-pages (= 134)
   guard-jekyll-plus
   guard-livereload
+  json
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://deliveroo.engineering" # the base hostname & protocol for your site
 logo: /images/logo_engineering.svg
 twitter:
-  username: deliveroo
+  username: deliverooeng
 
 repository: "deliveroo/deliveroo.engineering"
 

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,9 @@ description: > # this means to ignore newlines until "baseurl:"
   Deliveroo engineering blog
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://deliveroo.engineering" # the base hostname & protocol for your site
+logo: /images/logo_engineering.svg
+twitter:
+  username: deliveroo
 
 repository: "deliveroo/deliveroo.engineering"
 
@@ -29,6 +32,7 @@ gems:
    - jekyll-sitemap
    - jekyll-feed
    - jekyll-paginate
+   - jekyll-seo-tag
 
 paginate: 3
 paginate_path: "/articles/page:num/"
@@ -47,7 +51,14 @@ defaults:
       type:       guidelines
     values:
       layout:     guidelines
-
+  - scope:
+      path: ""
+    values:
+      image:
+        path: /images/logo_engineering.svg
+        height: 100
+        width: 735
+        type: image/svg
 exclude:
   - archive
   - Gemfile

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,35 +5,26 @@
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_newlines }}{% endif %}">
-  {% assign canonical_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
-  <meta property="og:url" content="{{ canonical_url }}">
-  <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
-  <meta property="og:image" content="{{site.url}}/images/logo_engineering.svg">
-  <meta property="og:image:width" content="735">
-  <meta property="og:image:height" content="100">
-  <meta property="og:image:type" content="image/svg">
-  
+
   {% if page.layout == 'post' %}
     {% for author in site.authors %}
       {% if author.name == page.author %}
         {% assign author = author %}
       {% endif %}
     {% endfor %}
-    <meta property="og:type" content="article">
-    <meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%d" }}">
     <meta property="article:author" content="{{ site.url }}/authors/{{ author.name | slugify }}">
     <meta property="article:section" content="Engineering Articles">
   {% else %}
     <meta property="og:type" content="website">
   {% endif %}
-  
+
   <script src="https://use.typekit.net/qxo7ukw.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ canonical_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
   <script type="text/javascript" src="/javascript/anchor.min.js" async></script>
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.slim.min.js" async></script>
   <script type="text/javascript" src="/javascript/application.js" async></script>
   {% include favicons.html %}
+  {% seo title=false %}
 </head>


### PR DESCRIPTION
This adds the [jekyll-seo-tag](https://github.com/jekyll/jekyll-seo-tag) plugin, which is available with `github-pages`. I removed the tags we set manually and are now set by the plugin.

~~- [ ] add twitter username per author for twitter cards~~