### PR TITLE
API Design: typo

### DIFF
--- a/_guidelines/api-design.md
+++ b/_guidelines/api-design.md
@@ -749,8 +749,9 @@ _links:
 ```
 
 
-Exceptionally, a collection representation, _may_ embed representations of
-the linked resources, which _may_ be incomplete, but _must_ include at least a link to `self`.
+Exceptionally, a collection representation _may_ embed representations of the
+linked resources, which _may_ be incomplete, but _must_ include at least a
+mandatory link to `self`.
 
 Note that as for other use cases of `_embedded`, there should be a very robust
 reason to do so as it makes using the API more complex (partial representations,

--- a/_guidelines/api-design.md
+++ b/_guidelines/api-design.md
@@ -749,7 +749,7 @@ _links:
 ```
 
 
-Exceptionally, a collection representation, _may_ embedded representations of
+Exceptionally, a collection representation, _may_ embed representations of
 the linked resources, which _may_ be incomplete, but _must_ include at least a link to `self`.
 
 Note that as for other use cases of `_embedded`, there should be a very robust

--- a/_guidelines/api-design.md
+++ b/_guidelines/api-design.md
@@ -750,8 +750,7 @@ _links:
 
 
 Exceptionally, a collection representation, _may_ embedded representations of
-the linked resources, which _may_ be incomplete, but _must_ include at least a
-the mandatory link to `self`.
+the linked resources, which _may_ be incomplete, but _must_ include at least a link to `self`.
 
 Note that as for other use cases of `_embedded`, there should be a very robust
 reason to do so as it makes using the API more complex (partial representations,


### PR DESCRIPTION
>a the

That caught my eye.

I decided to remove the "the". While I was at it, I removed "mandatory" because it's redundant (it follows "_must_ include").

---

Update: also spotted another typo in that sentence and fixed it; "_may_ embedded" -> "_may_ embed"