### PR TITLE
Change filter on Careers page to refer to Engineering group on Workable

### DIFF
--- a/javascript/careers.js
+++ b/javascript/careers.js
@@ -10,7 +10,7 @@
 
     $groups.each(function() {
       $group = jQuery(this);
-      if ($group.text() == "Product Team") {
+      if ($group.text() == "Engineering") {
         $list = $group.next();
         $list.removeAttr("style");
         $('#careers').append($list);


### PR DESCRIPTION
This changes the filter setting for the workable JS on the careers page to pull in listings under `Engineering` rather than `Product Team` (which recruitment no longer uses).