### PR TITLE
docs(services): change "payloads" for "states"

### DIFF
--- a/_guidelines/services.md
+++ b/_guidelines/services.md
@@ -174,7 +174,7 @@ In particular (but not limited to):
 Or in other words, **push > poll**.
 
 <aside>
-#### Why no payloads in events?
+#### Why no states in events?
 
 Events should not include an entity representation because that places
 enormous constraints on the bus infrastructure: in terms of data,


### PR DESCRIPTION
You advise not to use payloads but the actual cases you come up with are only related to state modifications via states duplication (via the payload). And you are totally right that this is a no go.
However, payloads could totally be part of the definition of an event as they could be its attributes (and not the changes performed by the event on the entity).

Check "How it Works" on http://eventedapi.org/spec/

I'd be glad to go further with you guys about that.