### PR TITLE
Fix trailing ``` in guidelines/meta

### DIFF
--- a/_guidelines/00-meta.md
+++ b/_guidelines/00-meta.md
@@ -124,12 +124,10 @@ Markdown supports several different types of indicating code blocks, but to
 take advantage of syntax highlighting, use the following format (without any
 indentation):
 
-```markdown
-  ```ruby
-  def what?
-    42
-  end
-  ```
-```
+    ```ruby
+    def what?
+      42
+    end
+    ```
 
 [kramdown]: http://kramdown.gettalong.org/documentation.html


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1845636/30512372-f100d0ce-9ae5-11e7-8420-0b56f00678a5.png)

After:
![after](https://user-images.githubusercontent.com/1845636/30512374-f5c2c02c-9ae5-11e7-8513-b6f1ee40b76f.png)

It looks like the markdown parser doesn't like the nested code blocks, this commit replaces the outer block with an indent instead.