### PR TITLE
Use CSS grid to display the list of other articles

### DIFF
--- a/_sass/layout/content.scss
+++ b/_sass/layout/content.scss
@@ -163,6 +163,17 @@ section {
       margin-top: 20px;
       text-align: center;
 
+      @include min-width(tablet_small) {
+        display: grid;
+        grid-template-columns: auto auto;
+        grid-auto-rows: 1fr;
+        grid-gap: 10px 20px;
+      }
+
+      @include min-width(desktop_small) {
+        grid-template-columns: auto auto auto;
+      }
+
       li {
         color: color(anchovy);
         line-height: 1.8;


### PR DESCRIPTION
Minor tweak which improves how the list of other articles displays, to make it more space-efficient.

Above 640px wide:

![img](http://snap.kapowaz.net/o7tp4.png)

Above 800px wide:

![img](http://snap.kapowaz.net/3f2xj.png)