### PR TITLE
EB-18 Add Google Analytics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     formatador (0.2.5)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    github-pages (186)
+    github-pages (187)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
       jekyll (= 3.7.3)
@@ -50,7 +50,7 @@ GEM
       jekyll-relative-links (= 0.5.3)
       jekyll-remote-theme (= 0.3.1)
       jekyll-sass-converter (= 1.5.2)
-      jekyll-seo-tag (= 2.4.0)
+      jekyll-seo-tag (= 2.5.0)
       jekyll-sitemap (= 1.2.0)
       jekyll-swiss (= 0.4.0)
       jekyll-theme-architect (= 0.1.1)
@@ -101,7 +101,7 @@ GEM
       guard (~> 2.8)
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
-    html-pipeline (2.8.0)
+    html-pipeline (2.8.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
@@ -159,7 +159,7 @@ GEM
       rubyzip (>= 1.2.1, < 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.4.0)
+    jekyll-seo-tag (2.5.0)
       jekyll (~> 3.3)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
@@ -231,7 +231,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -276,7 +276,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 186)
+  github-pages (= 187)
   guard-jekyll-plus
   guard-livereload
 
@@ -284,4 +284,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120984747-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-120984747-1');
+</script>

--- a/_includes/cookie_consent.html
+++ b/_includes/cookie_consent.html
@@ -1,0 +1,20 @@
+<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
+<script>
+    window.addEventListener("load", function(){
+        window.cookieconsent.initialise({
+            "palette": {
+                "popup": {
+                    "background": "#ffffff"
+                },
+                "button": {
+                    "background": "#440063"
+                }
+            },
+            "position": "bottom-left",
+            "content": {
+                "message": "Our site uses Cookies (chocolate chip, of course).",
+                "href": "https://deliveroo.co.uk/cookies"
+            }
+        })});
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,4 +23,6 @@
   <script type="text/javascript" src="/javascript/application.js" async></script>
   {% include favicons.html %}
   {% seo title=false %}
+  {% include cookie_consent.html %}
+  {% include analytics.html %}
 </head>


### PR DESCRIPTION
Currently we have no insight into the amount of visitors the Engineering blog has, or how many times specific articles are read. With this PR we will add Google Analytics to the Engineering blog to give us those insights.

Additionally, a cookie consent banner has been added to inform people of the use of cookies on the blog. I've used the same copy and explainer link for the cookie consent banner as on deliveroo.co.uk.

How the cookie consent banner works:

![2018-07-10 11 47 07](https://user-images.githubusercontent.com/697118/42509653-88a1f762-8444-11e8-8247-a8b47b5d3255.gif)
