### PR TITLE
[EB-13] Add `jekyll-admin` plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ WORKDIR /usr/src/app/deliveroo.engineering
 RUN gem install bundler && bundle install -j8
 
 EXPOSE 4000
+ENV DISABLE_WHITELIST TRUE
 ENTRYPOINT ["jekyll"]
 CMD ["serve", "-w", "-t", "-H", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
 # Set us up to reload pages interactively
 gem 'guard-jekyll-plus'
 gem 'guard-livereload'
+gem 'jekyll-admin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    backports (3.11.3)
     coderay (1.1.2)
     coffee-script (2.4.1)
       coffee-script-source
@@ -31,7 +32,7 @@ GEM
     formatador (0.2.5)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    github-pages (186)
+    github-pages (187)
       activesupport (= 4.2.10)
       github-pages-health-check (= 1.8.1)
       jekyll (= 3.7.3)
@@ -50,7 +51,7 @@ GEM
       jekyll-relative-links (= 0.5.3)
       jekyll-remote-theme (= 0.3.1)
       jekyll-sass-converter (= 1.5.2)
-      jekyll-seo-tag (= 2.4.0)
+      jekyll-seo-tag (= 2.5.0)
       jekyll-sitemap (= 1.2.0)
       jekyll-swiss (= 0.4.0)
       jekyll-theme-architect (= 0.1.1)
@@ -101,7 +102,7 @@ GEM
       guard (~> 2.8)
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
-    html-pipeline (2.8.0)
+    html-pipeline (2.8.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
@@ -120,6 +121,11 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-admin (0.8.0)
+      addressable (~> 2.4)
+      jekyll (~> 3.3)
+      sinatra (~> 1.4)
+      sinatra-contrib (~> 1.4)
     jekyll-avatar (0.5.0)
       jekyll (~> 3.0)
     jekyll-coffeescript (1.1.1)
@@ -159,7 +165,7 @@ GEM
       rubyzip (>= 1.2.1, < 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.4.0)
+    jekyll-seo-tag (2.5.0)
       jekyll (~> 3.3)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
@@ -231,7 +237,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -244,6 +250,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (2.0.5)
+    rack (1.6.10)
+    rack-protection (1.5.5)
+      rack
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -262,10 +273,22 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     shellany (0.0.1)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.0)
     thread_safe (0.3.6)
+    tilt (2.0.8)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
@@ -276,9 +299,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 186)
+  github-pages (= 187)
   guard-jekyll-plus
   guard-livereload
+  jekyll-admin
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/_config.yml
+++ b/_config.yml
@@ -29,13 +29,14 @@ kramdown:
 
 # Plugins
 plugins:
-   - jekyll-mentions
-   - jemoji
-   - jekyll-redirect-from
-   - jekyll-sitemap
+   - jekyll-admin
    - jekyll-feed
+   - jekyll-mentions
    - jekyll-paginate
+   - jekyll-redirect-from
    - jekyll-seo-tag
+   - jekyll-sitemap
+   - jemoji
 
 paginate: 3
 paginate_path: "/articles/page:num/"
@@ -62,6 +63,14 @@ defaults:
         height: 100
         width: 735
         type: image/svg
+
+jekyll_admin:
+  hidden_links:
+    - pages
+    - staticfiles
+    - datafiles
+    - configuration
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
This will only be executed in the local development environment as
`jekyll-admin` is not part of the whitelisted plugins of `github-pages`.

Check it out by going to `http://localhost:4000/admin/collections/posts`

TODO:
- [ ] Add documentation
- [ ] Create script to make it easier to submit a pull request with a new post

<img width="1435" alt="screen shot 2018-07-11 at 10 03 49" src="https://user-images.githubusercontent.com/570608/42561931-5c021b20-84f2-11e8-87b0-8f703427f931.png">

