### PR TITLE
Fix careers link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ twitter:
 repository: "deliveroo/deliveroo.engineering"
 
 external_links:
-  careers: "https://careers.deliveroo.co.uk/?team=engineering"
+  careers: "https://careers.deliveroo.co.uk/?team=engineering-team"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
The "Work with us!" link is currently using the wrong team ID from the list (`engineering` instead of `engineering-team`)