### PR TITLE
Configures "More articles" to go to the right page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ plugins:
    - jekyll-paginate
    - jekyll-seo-tag
 
-paginate: 3
+paginate: 9
 paginate_path: "/articles/page:num/"
 
 collections:

--- a/_data/offsets.yml
+++ b/_data/offsets.yml
@@ -1,0 +1,3 @@
+latest_articles: 1
+recent_articles: 3
+other_articles: 14

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: deliveroo.engineering
 
 <section id="latest-post">
   <div class="post latest">
-    {% for _page in site.posts limit: 1 %}
+    {% for _page in site.posts limit: site.data.offsets.latest_articles %}
       <h3><a href="{{ site.baseurl }}{{ _page.url }}">{{ _page.title }}</a></h3>
       <p class="byline">{% include byline.html authors=_page.authors date=_page.date %}</p>
       <blockquote>
@@ -19,12 +19,12 @@ title: deliveroo.engineering
   </div>
 </section>
 
-{% if site.posts.size > 1 %}
+{% if site.posts.size > site.data.offsets.latest_articles %}
   <hr>
 
   <h2>Recent Articles</h2>
   <section id="recent-posts">
-    {% for _page in site.posts limit: 3 offset: 1 %}
+    {% for _page in site.posts limit: site.data.offsets.recent_articles offset: site.data.offsets.latest_articles %}
       <div class="post recent">
         <h3><a href="{{ site.baseurl }}{{ _page.url }}">{{ _page.title }}</a></h3>
         <p class="byline">{% include byline.html authors=_page.authors date=_page.date %}</p>
@@ -40,21 +40,27 @@ title: deliveroo.engineering
   </section>
 {% endif %}
 
-{% if site.posts.size > 4 %}
+{% assign other_articles_offset = site.data.offsets.latest_articles | plus: site.data.offsets.recent_articles %}
+{% if site.posts.size > other_articles_offset %}
   <hr>
 
   <h2>Other Articles</h2>
   <section id="other-articles">
-    {% if site.posts.size > 4 %}
-      <ul class="articles">
-        {% for _page in site.posts limit: 17 offset: 4 %}
-          <li>
-            <a href="{{ site.baseurl }}{{ _page.url }}" title="{{ _page.title }}">{{ _page.title }}</a>
-            {% include byline.html authors=_page.authors date=_page.date %}
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-    <p class="more"><a href="{{site.data.routes.articles}}">More articles…</a></p>
+    <ul class="articles">
+      {% for _page in site.posts limit: site.data.offsets.other_articles offset: other_articles_offset %}
+        <li>
+          <a href="{{ site.baseurl }}{{ _page.url }}" title="{{ _page.title }}">{{ _page.title }}</a>
+          {% include byline.html authors=_page.authors date=_page.date %}
+        </li>
+      {% endfor %}
+    </ul>
+    {% assign page_offset =
+      site.data.offsets.latest_articles |
+        plus: site.data.offsets.recent_articles |
+        plus: site.data.offsets.other_articles |
+        divided_by: site.paginate |
+        plus: 1
+    %}
+    <p class="more"><a href="{{ site.data.routes.articles }}page{{ page_offset }}">More articles…</a></p>
   </section>
 {% endif %}


### PR DESCRIPTION
Currently on https://deliveroo.engineering we show 21 articles on the homepage, and if you click More Articles, the pagination shows articles 1-3 and you need to click through many pages to get to any articles that were not shown on the homepage.

- Calculates what the "next page" should be given the articles on the homepage. It should always take you to the page with the first article not shown on the homepage.
- How many articles are shown in each section on the homepage is now configurable in a yml file
- Increases pagination to 9; we now have enough articles to not restrict the number of articles per page so much; less clicky-clicky to get all the way through the backlog of articles.