### PR TITLE
Don't auto-update github-pages gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.7.5'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+gem 'github-pages', group: :jekyll_plugins
 
 # Set us up to reload pages interactively
 gem 'guard-jekyll-plus'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 225)
+  github-pages
   guard-jekyll-plus
   guard-livereload
 


### PR DESCRIPTION
This was causing an issue when the version in Gemfile (which was dynamic) had conflicts with the version in Gemfile.lock.

In general it's not a great idea to have the contents of the Gemfile changing dynamically on each invocation if the Gemfile.lock is also checked in, as those could end up conflicting, and it means that a previously working commit might fail to build if run at a different point in time, which is probably not the intention of any project that is checking in a lockfile.

Depending in a more traditional way will necessitate a `bundle update` to change the version of `github-pages` in use, but that is the way most Ruby developers would expect it to work anyway (principle of least surprise), and is how any other dependencies already work as well. If there was a good reason to make this dependency in particular dynamic, I didn't find it documented in the commit that introduced this code.

This should fix the build issue in #249.