### PR TITLE
fix: remove broken foodscene link

### DIFF
--- a/_data/routes.yml
+++ b/_data/routes.yml
@@ -3,7 +3,6 @@ articles:         "/articles/"
 repository:       "https://github.com/deliveroo/deliveroo.engineering"
 developer_portal: "https://developers.deliveroo.com/"
 design_blog:      "https://deliveroo.design/"
-food_blog:        "https://foodscene.deliveroo.co.uk"
 navigation:
   - url:   '/articles/'
     title: 'Articles'

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,6 @@
   <ul class="links">
     <li><a href="{{site.data.routes.developer_portal}}" target="_blank">Deliveroo Developers</a></li>
     <li><a href="{{site.data.routes.design_blog}}" target="_blank">Deliveroo Design</a></li>
-    <li><a href="{{site.data.routes.food_blog}}" target="_blank">Deliveroo Foodscene</a></li>
     <li>
       <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
       <a href="https://twitter.com/DeliverooEng?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">


### PR DESCRIPTION
Appears this site is no longer active and instead redirects you to Deliveroo T&Cs