### PR TITLE
fix(styles): don't use sans-serif font for monospace fonts

### DIFF
--- a/_sass/abstract/_typography.scss
+++ b/_sass/abstract/_typography.scss
@@ -16,8 +16,8 @@ $font-sizes: (
 $font-families: (
   title:            (Stratos, Helvetica Neue, Helvetica, Arial, sans-serif),
   title-loaded:     (Stratos, Helvetica Neue, Helvetica, Arial, sans-serif),
-  monospace:        (PlexSans, Menlo, Ubuntu Mono, Lucida Console, Monaco, monospace),
-  monospace-loaded: (PlexSans, SourceCodePro, Menlo, Ubuntu Mono, Lucida Console, Monaco, monospace),
+  monospace:        (Menlo, Ubuntu Mono, Lucida Console, Monaco, monospace),
+  monospace-loaded: (SourceCodePro, Menlo, Ubuntu Mono, Lucida Console, Monaco, monospace),
 );
 
 @function font-size($size) {

--- a/_sass/base/_default.scss
+++ b/_sass/base/_default.scss
@@ -33,7 +33,7 @@ a {
 } // a
 
 code, kbd, pre, samp {
-  @include font-family(monospace, 'PlexSans');
+  @include font-family(monospace);
   line-height: 1.4;
 }
 
@@ -71,7 +71,6 @@ h2 {
 }
 
 h3 {
-  @include font-family(monospace, 'PlexSans');
   font-size: font-size(small-heading);
   line-height: 32px;
 

--- a/_sass/base/_default.scss
+++ b/_sass/base/_default.scss
@@ -33,7 +33,7 @@ a {
 } // a
 
 code, kbd, pre, samp {
-  @include font-family(monospace);
+  @include font-family(monospace, 'SourceCodePro');
   line-height: 1.4;
 }
 


### PR DESCRIPTION
As it doesn't make sense, and poorly renders compared to being the
monospace fonts that are intended i.e. for code snippets.
